### PR TITLE
Add simple rake task

### DIFF
--- a/lib/envy/environment.rb
+++ b/lib/envy/environment.rb
@@ -1,5 +1,7 @@
 module Envy
   class Environment
+    include Enumerable
+
     attr_reader :env
 
     def initialize(env = ENV)
@@ -19,6 +21,10 @@ module Envy
 
     def [](name)
       @variables[name]
+    end
+
+    def each(&block)
+      @variables.values.each(&block)
     end
   end
 end

--- a/lib/envy/tasks.rb
+++ b/lib/envy/tasks.rb
@@ -1,0 +1,11 @@
+desc "Show environment variables that the application uses."
+task :env do
+  Envy.env.each do |variable|
+    description = variable.options[:description]
+    next unless description
+
+    puts description.gsub(/^/m, "# ")
+    puts "# #{variable.name.to_s.upcase}=#{variable.default}"
+    puts
+  end
+end


### PR DESCRIPTION
Here's a first stab at a rake task to show 

```
$ rake env
# The camo image proxy URL. This is used to rewrite HTTP <img> tag URLs left
# in user content (like comments and issue bodies) through the SSL image
# proxy, avoiding browser mixed content warnings.
# IMAGE_PROXY_URL=https://example.com/img

# The secret token key used to sign generated image proxy URLs.
# IMAGE_PROXY_KEY=

# Should external images be allowed to be loaded as subresouces outside
# of our whitelisted set. Enabling this enforces the img-src CSP.
# RESTRICT_EXTERNAL_IMAGES=true

…
```
### Questions
- [ ] does that format make sense?
- [ ] Currently it's only showing the default values. Would it make sense to show both the default values and the current values?
- [ ] Should the variables be sorted in any way besides the order that they are defined?
