### PR TITLE
Add #type method to DSL for adding new types

### DIFF
--- a/lib/envy/dsl.rb
+++ b/lib/envy/dsl.rb
@@ -8,22 +8,21 @@ module Envy
 
     def initialize(environment)
       @environment = environment
+
+      type :string,  Envy::Variable
+      type :boolean, Envy::Boolean
+      type :integer, Envy::Integer
+    end
+
+    def type(type_name, type_class)
+      singleton = class << self; self; end;
+      singleton.send :define_method, type_name do |name, *args, &default|
+        add type_class.new(environment, name, *args, &default)
+      end
     end
 
     def desc(description)
       @last_description = description
-    end
-
-    def string(name, options = {}, &default)
-      add Variable.new(environment, name, options, &default)
-    end
-
-    def integer(name, options = {}, &default)
-      add Integer.new(environment, name, options, &default)
-    end
-
-    def boolean(name, options = {}, &default)
-      add Boolean.new(environment, name, options, &default)
     end
 
     def eval(filename)


### PR DESCRIPTION
Talked with @jnunemaker about this and he suggested making a really easy way to define new types. In his instance, he uses [morphine](https://github.com/bkeepers/morphine) to do both what envy will do (process external configuration from the environment) and configuration management of the services in an application. He could imagine using this instead if he could add his own types.

This adds the `type` method to the DSL, which which would make it easy to add custom types.  For example, we don't currently have an `array` type, so you could declare one in your `Envfile` with:

``` ruby
class EnvArray < Envy::Variable
  def cast(value)
    value ? value.split(",") : []
  end
end

type :array, EnvArray
```
# TODO:
- [ ] Clean up and document methods that a type must respond to:
  - [ ] `#name`
  - [ ] `#accessor_name` - this is the name of the method that will be defined. Maybe default to `#name` if it's not defined?
  - [ ] `#accessor` - this is the "reader" that fetches the value of the variable. Rename to `#value`?
