### PR TITLE
rename Variable#accessor to #value

### DIFF
--- a/lib/envy/boolean.rb
+++ b/lib/envy/boolean.rb
@@ -3,7 +3,7 @@ module Envy
   #
   # Boolean-ish values get cast into true/false boolean values.
   class Boolean < Variable
-    def accessor_name
+    def method_name
       "#{name}?"
     end
 

--- a/lib/envy/environment.rb
+++ b/lib/envy/environment.rb
@@ -5,16 +5,16 @@ module Envy
     def initialize(env = ENV)
       @env = env
       @variables = {}
-      extend accessors
+      extend readers
     end
 
-    def accessors
-      @accessors ||= Module.new
+    def readers
+      @readers ||= Module.new
     end
 
     def add(variable)
       @variables[variable.name] = variable
-      accessors.send :define_method, variable.accessor_name, &variable.method(:accessor)
+      readers.send :define_method, variable.method_name, &variable.method(:value)
     end
 
     def [](name)

--- a/lib/envy/variable.rb
+++ b/lib/envy/variable.rb
@@ -44,19 +44,19 @@ module Envy
       end
     end
 
-    # The name of the accessor method that will be defined on the `environment`
+    # The name of the reader method that will be defined on the `environment`
     # instance. Override in subclasses to customize.
-    def accessor_name
+    def method_name
       name
     end
 
     # The method that gets defined on the environment to read this variable.
     #
     # Returns the cast environment variable.
-    def accessor
+    def value
       return @value if defined?(@value)
 
-      @value = cast(value).tap do |result|
+      @value = cast(fetch).tap do |result|
         raise ArgumentError, "#{name} is required" if required? && result.nil?
       end
     end
@@ -64,7 +64,7 @@ module Envy
     # Fetch the value from the environment
     #
     # Returns a string from the environment variable, or the default value.
-    def value
+    def fetch
       environment.env.fetch(from) { default }
     end
 

--- a/spec/envy/variable_spec.rb
+++ b/spec/envy/variable_spec.rb
@@ -7,24 +7,24 @@ describe Envy::Variable do
     Envy::Variable.new(environment, :test, options) { Time.now.to_s }
   end
 
-  describe "accessor" do
+  describe "value" do
     it "memoizes default values" do
-      expect(subject.accessor).to equal(subject.accessor)
+      expect(subject.value).to equal(subject.value)
     end
 
     it "memoizes cast values" do
       environment.env["TEST"] = "42"
-      value = subject.accessor
+      value = subject.value
       expect(subject).not_to receive(:cast)
-      expect(subject.accessor).to equal(value)
+      expect(subject.value).to equal(value)
     end
   end
 
   describe "reset" do
     it "clears memoized value" do
-      value = subject.accessor
+      value = subject.value
       subject.reset
-      expect(subject.accessor).not_to equal(value)
+      expect(subject.value).not_to equal(value)
     end
   end
 
@@ -37,7 +37,7 @@ describe Envy::Variable do
       environment.env["TEST"] = "not used"
       environment.env["OTHER_VAR"] = "the real slim shady"
 
-      expect(subject.accessor).to eql("the real slim shady")
+      expect(subject.value).to eql("the real slim shady")
     end
   end
 end


### PR DESCRIPTION
`#accessor` was a weird name for what it really does. This renames it to `#value`, which I think makes a little more sense, and renames other uses of "accessor".
