### PR TITLE
Required by default

### DIFF
--- a/lib/envy/variable.rb
+++ b/lib/envy/variable.rb
@@ -11,7 +11,7 @@ module Envy
     def initialize(environment, name, options = {}, &default)
       @environment = environment
       @name = name
-      @options = options
+      @options = {:required => true}.merge(options)
       @default = default || options[:default]
     end
 

--- a/spec/envy/dsl_spec.rb
+++ b/spec/envy/dsl_spec.rb
@@ -23,7 +23,7 @@ describe Envy::DSL do
   end
 
   describe "integer" do
-    before { dsl.integer :int }
+    before { dsl.integer :int, :required => false }
 
     it "returns nil if not defined" do
       expect(config.int).to be(nil)
@@ -41,7 +41,7 @@ describe Envy::DSL do
   end
 
   describe "boolean" do
-    before { dsl.boolean :bool }
+    before { dsl.boolean :bool, :required => false }
 
     ["0", "false", false, "off", "no", "f", "n"].each do |input|
       it "casts #{input.inspect} to false" do
@@ -71,28 +71,27 @@ describe Envy::DSL do
   end
 
   describe "uri" do
+    before { dsl.uri :app_url, :required => false }
+
     it "returns nil if not defined" do
-      dsl.uri :app_url
       expect(config.app_url).to be(nil)
     end
 
     it "returns a URI" do
       env["APP_URL"] = "http://example.com"
-      dsl.uri :app_url
       expect(config.app_url).to be_instance_of(Addressable::URI)
       expect(config.app_url.to_s).to eq("http://example.com")
     end
   end
 
   describe "decimal" do
+    before { dsl.decimal :price, :required => false }
     it "returns nil if not defined" do
-      dsl.decimal :price
       expect(config.price).to be(nil)
     end
 
     it "returns a decimal" do
       env["PRICE"] = "1.23"
-      dsl.decimal :price
       expect(config.price).to be_instance_of(BigDecimal)
       expect(config.price).to eq(BigDecimal.new("1.23"))
     end


### PR DESCRIPTION
This switches the default to be required. I started changing the option name to `:optional`, but came across a few instances where it makes things weird. Here's an example of a config I already have:

``` ruby
boolean :analytics_enabled, :default => true
string :analytics_id, :required => :analytics_enabled?
```

This config would not work if `:required` was changed to `:optional`. Would it make sense to support both and make them mutually exclusive?

Closes #16

/cc @laserlemon 
