### PR TITLE
Validate the presence of environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,16 +90,16 @@ integer :request_timeout, :default => 10
 
 ### `:required`
 
-The `:required` option can be used to enforce that a variable be defined by the environment.
+All defined variables without a default value are required. When the `Envfile` is loaded, it will raise an exception if the required keys are not set.
+
+```
+Missing environment variables: ENCRYPTION_KEY
+```
+
+The `:required` option can be set to `false` for optional values.
 
 ```ruby
-string :encryption_key, :required => true
-```
-
-When the `Envfile` is loaded, it will raise an exception if the required keys are not set.
-
-```
-ArgumentError: ENCRYPTION_KEY must be set in `ENV`
+string :encryption_key, :required => false
 ```
 
 ### `:default`

--- a/lib/envy/environment.rb
+++ b/lib/envy/environment.rb
@@ -10,11 +10,16 @@ module Envy
       extend readers
     end
 
-    # Evaluate the given Envfile
+    # Configure the environment.
+    #
+    # filename - An optional String path to an Envfile to evaluate.
+    # block - An optional block to evaluate.
     #
     # Returns this Environment instance
-    def configure(filename = "Envfile")
-      Envy::DSL.new(self).eval(filename)
+    def configure(filename = nil, &block)
+      dsl = Envy::DSL.new(self)
+      dsl.eval(filename) if filename
+      dsl.instance_eval(&block) if block
       self
     end
 

--- a/lib/envy/environment.rb
+++ b/lib/envy/environment.rb
@@ -51,7 +51,7 @@ module Envy
     def validate
       missing = @variables.values.select(&:missing?)
       unless missing.empty?
-        raise ArgumentError, "Missing environment variables: #{missing.map(&:from).join(', ')}"
+        raise "Missing environment variables: #{missing.map(&:from).join(', ')}"
       end
     end
   end

--- a/lib/envy/environment.rb
+++ b/lib/envy/environment.rb
@@ -47,5 +47,12 @@ module Envy
     def reset
       @variables.values.each(&:reset)
     end
+
+    def validate
+      missing = @variables.values.select(&:missing?)
+      unless missing.empty?
+        raise ArgumentError, "Missing environment variables: #{missing.map(&:from).join(', ')}"
+      end
+    end
   end
 end

--- a/lib/envy/railtie.rb
+++ b/lib/envy/railtie.rb
@@ -11,7 +11,7 @@ module Envy
       ENV["ENVFILE"] || Rails.root.join('Envfile')
     end
 
-    config.before_configuration do |app|
+    config.before_configuration do
       $ENV = Envy.environment
 
       begin
@@ -20,6 +20,10 @@ module Envy
         # re-raise if ENVFILE is explicitly defined.
         raise if ENV["ENVFILE"]
       end
+    end
+
+    config.after_initialize do
+      Envy.environment.validate
     end
 
     rake_tasks do

--- a/lib/envy/variable.rb
+++ b/lib/envy/variable.rb
@@ -54,11 +54,12 @@ module Envy
     #
     # Returns the cast environment variable.
     def value
-      return @value if defined?(@value)
+      @value ||= cast(fetch)
+    end
 
-      @value = cast(fetch).tap do |result|
-        raise ArgumentError, "#{name} is required" if required? && result.nil?
-      end
+    # Returns true if the variable is required an a value is not provided.
+    def missing?
+      required? && fetch.nil?
     end
 
     # Fetch the value from the environment

--- a/spec/envy/dsl_spec.rb
+++ b/spec/envy/dsl_spec.rb
@@ -126,25 +126,6 @@ describe Envy::DSL do
     end
   end
 
-  describe ":required" do
-    it "raises an error if not supplied" do
-      dsl.string :required_thing, :required => true
-      expect { config.required_thing }.to raise_error(ArgumentError, /is required/)
-    end
-
-    it "raises an error if symbol returns true" do
-      dsl.string :conditionally_required, :required => :conditional?
-      expect(config).to receive(:conditional?).and_return(true)
-      expect { config.conditionally_required }.to raise_error(ArgumentError, /is required/)
-    end
-
-    it "does not raise an error if symbol returns false" do
-      dsl.string :conditionally_required, :required => :conditional?
-      expect(config).to receive(:conditional?).and_return(false)
-      expect(config.conditionally_required).to be(nil)
-    end
-  end
-
   describe "eval" do
     it "evaluates the given file" do
       dsl.eval(fixture_path("Envfile"))

--- a/spec/envy/environment_spec.rb
+++ b/spec/envy/environment_spec.rb
@@ -27,4 +27,17 @@ describe Envy::Environment do
       subject.reset
     end
   end
+
+  describe "validate" do
+    it "does not raise an error if all required variables are present" do
+      subject.configure { string :app_url }
+      subject.source["APP_URL"] = "https://example.com"
+      subject.validate
+    end
+
+    it "raises an ArgumentError if required variables are missing" do
+      subject.configure { string :app_url }
+      expect { subject.validate }.to raise_error(ArgumentError, /Missing.*APP_URL/)
+    end
+  end
 end

--- a/spec/envy/environment_spec.rb
+++ b/spec/envy/environment_spec.rb
@@ -37,7 +37,7 @@ describe Envy::Environment do
 
     it "raises an ArgumentError if required variables are missing" do
       subject.configure { string :app_url }
-      expect { subject.validate }.to raise_error(ArgumentError, /Missing.*APP_URL/)
+      expect { subject.validate }.to raise_error(RuntimeError, /Missing.*APP_URL/)
     end
   end
 end

--- a/spec/envy/environment_spec.rb
+++ b/spec/envy/environment_spec.rb
@@ -12,6 +12,11 @@ describe Envy::Environment do
     it "returns the environment" do
       expect(subject.configure(fixture_path("Envfile"))).to be(subject)
     end
+
+    it "evaluates the block" do
+      subject.configure { string :from_block }
+      expect(subject).to respond_to(:from_block)
+    end
   end
 
   describe "reset" do

--- a/spec/envy/railtie_spec.rb
+++ b/spec/envy/railtie_spec.rb
@@ -26,6 +26,13 @@ describe Envy::Railtie do
     expect($ENV).to be(Envy.environment)
   end
 
+  it "validates declared variables after initialize" do
+    Envy.environment.configure { string :missing }
+    expect {
+      ActiveSupport.run_load_hooks(:after_initialize, application)
+    }.to raise_error(ArgumentError, /MISSING/)  
+  end
+
   context "when Envfile exists" do
     it "evalates the Envfile" do
       # Rails uses existance of config.ru and falls back to Dir.pwd to set Rails.root

--- a/spec/envy/railtie_spec.rb
+++ b/spec/envy/railtie_spec.rb
@@ -30,7 +30,7 @@ describe Envy::Railtie do
     Envy.environment.configure { string :missing }
     expect {
       ActiveSupport.run_load_hooks(:after_initialize, application)
-    }.to raise_error(ArgumentError, /MISSING/)  
+    }.to raise_error(RuntimeError, /MISSING/)  
   end
 
   context "when Envfile exists" do

--- a/spec/envy/variable_spec.rb
+++ b/spec/envy/variable_spec.rb
@@ -40,4 +40,45 @@ describe Envy::Variable do
       expect(subject.value).to eql("the real slim shady")
     end
   end
+
+  describe "required?" do
+    it "defaults to true" do
+      expect(Envy::Variable.new(environment, :test)).to be_required
+    end
+
+    it "is true if symbol returns true" do
+      expect(environment).to receive(:conditional?).and_return(true)
+      variable = Envy::Variable.new(environment, :test, :required => :conditional?)
+      expect(variable).to be_required
+    end
+
+    it "is false if symbol returns false" do
+      expect(environment).to receive(:conditional?).and_return(false)
+      variable = Envy::Variable.new(environment, :test, :required => :conditional?)
+      expect(variable).not_to be_required
+    end
+  end
+
+  describe "missing?" do
+    it "returns true if required and value is nil" do
+      variable = Envy::Variable.new(environment, :test)
+      expect(variable).to be_missing
+    end
+
+    it "returns false if not required" do
+      variable = Envy::Variable.new(environment, :test, :required => false)
+      expect(variable).not_to be_missing
+    end
+
+    it "returns false if a default is defined" do
+      variable = Envy::Variable.new(environment, :test) { "default" }
+      expect(variable).not_to be_missing
+    end
+
+    it "returns false if a value is provided" do
+      variable = Envy::Variable.new(environment, :test)
+      environment.source["TEST"] = "value"
+      expect(variable).not_to be_missing
+    end
+  end
 end


### PR DESCRIPTION
`Envy.environment.validate` will raise an error if the required environment variables are not defined and is call after Rails apps are initialized.

```
Missing environment variables: GITHUB_TOKEN
```
