### PR TITLE
Add support for Rails credentials

### DIFF
--- a/lib/envy/dsl.rb
+++ b/lib/envy/dsl.rb
@@ -3,25 +3,28 @@ require "envy/type/boolean"
 require "envy/type/decimal"
 require "envy/type/integer"
 require "envy/type/uri"
+require "envy/type/scope"
 
 module Envy
   class DSL
     attr_reader :environment
 
-    def initialize(environment)
+    def initialize(environment, scope: nil)
       @environment = environment
+      @scope = scope
 
       type :string,  Envy::Type::Variable
       type :boolean, Envy::Type::Boolean
       type :decimal, Envy::Type::Decimal
       type :integer, Envy::Type::Integer
       type :uri,     Envy::Type::URI
+      type :scope,   Envy::Type::Scope
     end
 
     def type(type_name, type_class)
       singleton = class << self; self; end;
       singleton.send :define_method, type_name do |name, **args, &transform|
-        environment.add type_class.new(environment, name, description: last_description, **args, &transform)
+        environment.add type_class.new(self, name, description: last_description, **args, &transform)
       end
     end
 
@@ -41,6 +44,10 @@ module Envy
 
     def method_missing(symbol, *args, &block)
       environment.send(symbol, *args, &block)
+    end
+
+    def variable_name(name)
+      [@scope&.from, name].compact.join("_").upcase
     end
 
     def respond_to?(symbol, include_all = false)

--- a/lib/envy/environment.rb
+++ b/lib/envy/environment.rb
@@ -48,7 +48,11 @@ module Envy
 
     # Reset memoized values for all variables
     def reset
-      @variables.values.each(&:reset)
+      each(&:reset)
+    end
+
+    def dup
+      self.class.new(@source)
     end
 
     def validate

--- a/lib/envy/environment.rb
+++ b/lib/envy/environment.rb
@@ -2,10 +2,8 @@ module Envy
   class Environment
     include Enumerable
 
-    attr_reader :source
-
-    def initialize(source = ENV)
-      @source = source
+    def initialize(source = nil, &block)
+      @source = source || block || ENV
       @variables = {}
       extend readers
     end
@@ -34,6 +32,14 @@ module Envy
 
     def [](name)
       @variables[name]
+    end
+
+    def fetch(key, default = nil, &block)
+      block ||= lambda { default }
+      value = @source[key]
+      value = default if value.nil?
+      value = block[key] if value.nil?
+      value
     end
 
     # Iterate over each defined environment variable.

--- a/lib/envy/environment.rb
+++ b/lib/envy/environment.rb
@@ -5,7 +5,8 @@ module Envy
     def initialize(source = nil, &block)
       @source = source || block || ENV
       @variables = {}
-      extend readers
+      @readers = Module.new
+      extend @readers
     end
 
     # Setup the environment.
@@ -21,13 +22,9 @@ module Envy
       self
     end
 
-    def readers
-      @readers ||= Module.new
-    end
-
     def add(variable)
       @variables[variable.name] = variable
-      readers.send :define_method, variable.method_name, &variable.method(:value)
+      @readers.send :define_method, variable.method_name, &variable.method(:value)
     end
 
     def [](name)

--- a/lib/envy/railtie.rb
+++ b/lib/envy/railtie.rb
@@ -12,10 +12,12 @@ module Envy
     end
 
     config.before_configuration do
-      $ENV = Envy.environment
+      $ENV = Envy.environment = Envy::Environment.new do |key|
+        ENV[key] || Rails.application.credentials[key.downcase]
+      end
 
       begin
-        Envy.environment.setup(envfile)
+        $ENV.setup(envfile)
       rescue Errno::ENOENT => e
         # re-raise if ENVFILE is explicitly defined.
         raise if ENV["ENVFILE"]
@@ -23,7 +25,7 @@ module Envy
     end
 
     config.after_initialize do
-      Envy.environment.validate
+      $ENV.validate
     end
 
     rake_tasks do

--- a/lib/envy/railtie.rb
+++ b/lib/envy/railtie.rb
@@ -18,6 +18,7 @@ module Envy
 
       begin
         $ENV.setup(envfile)
+
       rescue Errno::ENOENT => e
         # re-raise if ENVFILE is explicitly defined.
         raise if ENV["ENVFILE"]
@@ -25,7 +26,11 @@ module Envy
     end
 
     config.after_initialize do
-      $ENV.validate
+      begin
+        $ENV.validate
+      rescue => e
+        abort e.message
+      end
     end
 
     rake_tasks do

--- a/lib/envy/tasks.rb
+++ b/lib/envy/tasks.rb
@@ -1,7 +1,7 @@
 desc "Show environment variables that the application uses."
 task :env do
   Envy.environment.each do |variable|
-    description = variable.options[:description]
+    description = variable.description
 
     puts description.gsub(/^/m, "# ") if description
     puts "# #{variable.from}=#{variable.default}"

--- a/lib/envy/type/scope.rb
+++ b/lib/envy/type/scope.rb
@@ -1,0 +1,17 @@
+module Envy
+  module Type
+    class Scope < Variable
+      def initialize(dsl, name, description: nil, from: nil, &block)
+        from ||= dsl.variable_name(name)
+
+        new_dsl = Envy::DSL.new(dsl.environment.dup, scope: self)
+        super new_dsl, name, description: description, from: from, required: true
+        new_dsl.instance_eval(&block)
+      end
+
+      def value
+        dsl.environment
+      end
+    end
+  end
+end

--- a/lib/envy/type/uri.rb
+++ b/lib/envy/type/uri.rb
@@ -4,8 +4,8 @@ require "addressable/template"
 module Envy
   module Type
     class URI < Variable
-      def initialize(environment, name, template: nil, **args, &block)
-        super environment, name, **args, &block
+      def initialize(dsl, name, template: nil, **args, &block)
+        super dsl, name, **args, &block
 
         @template = Addressable::Template.new(template) if template
       end

--- a/lib/envy/type/variable.rb
+++ b/lib/envy/type/variable.rb
@@ -64,7 +64,7 @@ module Envy
       #
       # Returns a string from the environment variable, or the default value.
       def fetch
-        environment.source.fetch(@from) { default }
+        environment.fetch(@from) { default }
       end
 
       # Override in subclasses to perform casting.

--- a/lib/envy/type/variable.rb
+++ b/lib/envy/type/variable.rb
@@ -1,18 +1,18 @@
 module Envy
   module Type
     class Variable
-      attr_reader :environment, :name, :description, :from
+      attr_reader :dsl, :name, :description
 
-      # environment  - an instance of Envy::Environment
-      # name         - the name of the environment variable
+      # dsl  - an instance of Envy::Environment
+      # name - the name of the environment variable
       #
       # Options:
       #   description: - a friendly description of the environment variable
       #   required:    - a boolean indiciting if a value is required
       #   default:     - a default value or Proc if the variable is not set
       #   from:        - the name of the environment variable to fetch the value from
-      def initialize(environment, name, description: nil, required: true, default: nil, from: name.to_s.upcase, &transform)
-        @environment = environment
+      def initialize(dsl, name, description: nil, required: true, default: nil, from: nil, &transform)
+        @dsl = dsl
         @name = name
         @description = description
         @required = required
@@ -64,7 +64,12 @@ module Envy
       #
       # Returns a string from the environment variable, or the default value.
       def fetch
-        environment.fetch(@from) { default }
+        dsl.environment.fetch(from) { default }
+      end
+
+      # Name of variable in the environment
+      def from
+        @from || dsl.variable_name(name)
       end
 
       # Override in subclasses to perform casting.
@@ -85,7 +90,7 @@ module Envy
         if option.respond_to?(:call)
           option.call(*args)
         elsif option.respond_to?(:to_proc)
-          option.to_proc.call(environment, *args)
+          option.to_proc.call(dsl.environment, *args)
         else
           option
         end

--- a/spec/envy/dsl_spec.rb
+++ b/spec/envy/dsl_spec.rb
@@ -176,4 +176,45 @@ describe Envy::DSL do
       end.to raise_error(Errno::ENOENT)
     end
   end
+
+  describe "scope" do
+    it "define scoped accessors" do
+      envfile do
+        scope :aws do
+          string :access_key_id
+        end
+      end
+
+      env["AWS_ACCESS_KEY_ID"] = "xyz"
+      expect(envy.aws.access_key_id).to eq("xyz")
+    end
+
+    it "respects :from" do
+      envfile do
+        scope :recaptcha, from: "GOOGLE_RECAPTCHA" do
+          string :secret_key
+          string :public_key, from: "GRE_PUBLIC_KEY"
+        end
+      end
+
+      env["GOOGLE_RECAPTCHA_SECRET_KEY"] = "secret"
+      env["GRE_PUBLIC_KEY"] = "public"
+      expect(envy.recaptcha.secret_key).to eq("secret")
+      expect(envy.recaptcha.public_key).to eq("public")
+    end
+
+    it "does not accept default:" do
+      expect do
+        envfile { scope :test, default: "whoops!" }
+      end.to raise_error(ArgumentError, "unknown keyword: :default")
+    end
+
+    it "does not accept required:" do
+      expect do
+        envfile { scope :test, required: false }
+      end.to raise_error(ArgumentError, "unknown keyword: :required")
+    end
+
+    it "validates missing variables"
+  end
 end

--- a/spec/envy/dsl_spec.rb
+++ b/spec/envy/dsl_spec.rb
@@ -4,16 +4,16 @@ describe Envy::DSL do
   let(:env) { {} }
   let(:envy) { Envy::Environment.new(env) }
 
-  def procfile(&block)
+  def envfile(&block)
     envy.setup(&block)
   end
 
-  def self.procfile(&block)
-    before { procfile(&block) }
+  def self.envfile(&block)
+    before { envfile(&block) }
   end
 
   describe "desc" do
-    procfile do
+    envfile do
       desc "a description"
       string :described
 
@@ -32,7 +32,7 @@ describe Envy::DSL do
   describe "string" do
     it "returns the value" do
       env["STR"] = "a string"
-      procfile { string :str }
+      envfile { string :str }
 
       expect(envy.str).to eql("a string")
     end
@@ -40,7 +40,7 @@ describe Envy::DSL do
 
   describe "integer" do
     before do
-      procfile { integer :int, required: false }
+      envfile { integer :int, required: false }
     end
 
     it "returns nil if not defined" do
@@ -59,7 +59,7 @@ describe Envy::DSL do
   end
 
   describe "boolean" do
-    procfile { boolean :bool, required: false }
+    envfile { boolean :bool, required: false }
 
     ["0", "false", false, "off", "no", "f", "n"].each do |input|
       it "casts #{input.inspect} to false" do
@@ -89,7 +89,7 @@ describe Envy::DSL do
   end
 
   describe "uri" do
-    procfile { uri :app_url, required: false }
+    envfile { uri :app_url, required: false }
 
     it "returns nil if not defined" do
       expect(envy.app_url).to be(nil)
@@ -103,7 +103,7 @@ describe Envy::DSL do
   end
 
   describe "decimal" do
-    procfile { decimal :price, required: false }
+    envfile { decimal :price, required: false }
     it "returns nil if not defined" do
       expect(envy.price).to be(nil)
     end
@@ -117,18 +117,18 @@ describe Envy::DSL do
 
   describe ":default option" do
     it "returns the default if no value is provided" do
-      procfile { string :blank, default: "not blank" }
+      envfile { string :blank, default: "not blank" }
       expect(envy.blank).to eql("not blank")
     end
 
     it "does not return the default if a value is provided" do
-      procfile { boolean :bool, default: true }
+      envfile { boolean :bool, default: true }
       env["BOOL"] = 'false'
       expect(envy.bool?).to be(false)
     end
 
     it "gets value from other variable with a symbol" do
-      procfile do
+      envfile do
         string :default_from_other_var, default: :other_var
         string :other_var, default: "default"
       end
@@ -141,7 +141,7 @@ describe Envy::DSL do
     it "instance evals block to transform value" do
       env["MAGIC_NUMBER"] = 5
 
-      procfile do
+      envfile do
         integer :multiplier, default: 2
 
         integer :magic_number do |value|
@@ -155,7 +155,7 @@ describe Envy::DSL do
 
   describe "eval" do
     it "evaluates the given file" do
-      procfile do
+      envfile do
         eval File.expand_path("../../fixtures/Envfile", __FILE__)
       end
 
@@ -163,7 +163,7 @@ describe Envy::DSL do
     end
 
     it "works with a Pathname" do
-      procfile do
+      envfile do
         eval Pathname.new(File.expand_path("../../fixtures/Envfile", __FILE__))
       end
 
@@ -172,7 +172,7 @@ describe Envy::DSL do
 
     it "raises Errno::ENOENT if file does not exist" do
       expect do
-        procfile { eval "notfound" }
+        envfile { eval "notfound" }
       end.to raise_error(Errno::ENOENT)
     end
   end

--- a/spec/envy/environment_spec.rb
+++ b/spec/envy/environment_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
 
 describe Envy::Environment do
-  subject { Envy::Environment.new({}) }
+  let(:env) { {} }
+  subject { Envy::Environment.new(env) }
 
   describe "setup" do
     it "loads the envfile" do
@@ -30,8 +31,8 @@ describe Envy::Environment do
 
   describe "validate" do
     it "does not raise an error if all required variables are present" do
+      env["APP_URL"] = "https://example.com"
       subject.setup { string :app_url }
-      subject.source["APP_URL"] = "https://example.com"
       subject.validate
     end
 

--- a/spec/envy/railtie_spec.rb
+++ b/spec/envy/railtie_spec.rb
@@ -44,7 +44,7 @@ describe Envy::Railtie do
     end
 
     it "validates declared variables" do
-      expect { subject }.to raise_error(RuntimeError, /FROM_ENVFILE/)
+      expect { silence { subject } }.to raise_error(SystemExit, /FROM_ENVFILE/)
     end
   end
 

--- a/spec/envy/railtie_spec.rb
+++ b/spec/envy/railtie_spec.rb
@@ -4,16 +4,20 @@ require "envy/railtie"
 require "rake"
 
 describe Envy::Railtie do
-  let(:application) { Class.new(Rails::Application) }
+  let(:application) do
+    Class.new(Rails::Application) do
+      config.eager_load = false
+      config.logger = ActiveSupport::Logger.new($stdout)
+    end
+  end
 
   before do
     @env = ENV.to_h
-    Rails.application = nil
+    Rails.application = Envy.environment = $ENV = nil
   end
 
   after do
     ENV.replace @env
-    Envy.environment = nil
   end
 
   it "defines rake tasks" do
@@ -22,22 +26,25 @@ describe Envy::Railtie do
   end
 
   it "sets $ENV" do
-    application
+    application.initialize!
     expect($ENV).to be(Envy.environment)
   end
 
-  it "validates declared variables after initialize" do
-    Envy.environment.setup { string :missing }
-    expect {
-      ActiveSupport.run_load_hooks(:after_initialize, application)
-    }.to raise_error(RuntimeError, /MISSING/)
-  end
-
   context "when Envfile exists" do
-    it "evalates the Envfile" do
+    subject do
       # Rails uses existance of config.ru and falls back to Dir.pwd to set Rails.root
-      Dir.chdir(fixture_path) { application }
-      expect(Envy.environment).to respond_to(:from_envfile)
+      Dir.chdir(fixture_path) { application.initialize! }
+      application
+    end
+
+    it "evalates the Envfile" do
+      ENV["FROM_ENVFILE"] = "yep"
+      subject
+      expect($ENV.from_envfile).to eq("yep")
+    end
+
+    it "validates declared variables" do
+      expect { subject }.to raise_error(RuntimeError, /FROM_ENVFILE/)
     end
   end
 
@@ -58,6 +65,29 @@ describe Envy::Railtie do
     it "does not raise error" do
       expect(File.exists?("#{Dir.pwd}/Envfile")).to be(false)
       expect { application }.not_to raise_error
+    end
+  end
+
+  context "using Rails.credentials" do
+    before do
+      ENV["ENVFILE"] = fixture_path("Envfile.credentials")
+      ENV["FROM_ENV"] = "not secret"
+
+      application.credentials = ActiveSupport::InheritableOptions.new(
+        from_credentials: "secretz"
+      )
+    end
+
+    it "merges credentials" do
+      application.initialize!
+      expect(Envy.environment.from_credentials).to eq("secretz")
+      expect(Envy.environment.from_env).to eq("not secret")
+    end
+
+    it "gives ENV higher predence" do
+      ENV["FROM_CREDENTIALS"] = "overridden"
+      application.initialize!
+      expect(Envy.environment.from_credentials).to eq("overridden")
     end
   end
 end

--- a/spec/envy/variable_spec.rb
+++ b/spec/envy/variable_spec.rb
@@ -1,8 +1,10 @@
 require "spec_helper"
 
 describe Envy::Type::Variable do
-  let(:environment) { Envy::Environment.new({}) }
+  let(:env) { {} }
+  let(:environment) { Envy::Environment.new(env) }
   let(:options) { {} }
+
   subject do
     described_class.new(environment, :test, default: -> { rand }, **options)
   end
@@ -13,7 +15,7 @@ describe Envy::Type::Variable do
     end
 
     it "memoizes cast values" do
-      environment.source["TEST"] = "42"
+      env["TEST"] = "42"
       value = subject.value
       expect(subject).not_to receive(:cast)
       expect(subject.value).to equal(value)
@@ -34,8 +36,8 @@ describe Envy::Type::Variable do
     end
 
     it "fetches value from given name" do
-      environment.source["TEST"] = "not used"
-      environment.source["OTHER_VAR"] = "the real slim shady"
+      env["TEST"] = "not used"
+      env["OTHER_VAR"] = "the real slim shady"
 
       expect(subject.value).to eql("the real slim shady")
     end
@@ -77,7 +79,7 @@ describe Envy::Type::Variable do
 
     it "returns false if a value is provided" do
       variable = described_class.new(environment, :test)
-      environment.source["TEST"] = "value"
+      env["TEST"] = "value"
       expect(variable).not_to be_missing
     end
   end

--- a/spec/envy/variable_spec.rb
+++ b/spec/envy/variable_spec.rb
@@ -48,15 +48,18 @@ describe Envy::Type::Variable do
       expect(described_class.new(environment, :test)).to be_required
     end
 
-    it "is true if symbol returns true" do
-      expect(environment).to receive(:conditional?).and_return(true)
+    it "returns result of symbol" do
       variable = described_class.new(environment, :test, required: :conditional?)
+
+      expect(environment).to receive(:conditional?).and_return(true)
       expect(variable).to be_required
+
+      expect(environment).to receive(:conditional?).and_return(false)
+      expect(variable).not_to be_required
     end
 
-    it "is false if symbol returns false" do
-      expect(environment).to receive(:conditional?).and_return(false)
-      variable = described_class.new(environment, :test, required: :conditional?)
+    it "calls block" do
+      variable = described_class.new(environment, :test, required: -> { false })
       expect(variable).not_to be_required
     end
   end

--- a/spec/fixtures/Envfile.credentials
+++ b/spec/fixtures/Envfile.credentials
@@ -1,0 +1,2 @@
+string :from_credentials
+string :from_env

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,29 @@
 require "envy"
 require "pry"
 
-module Fixtures
+module Helpers
   def fixture_path(*args)
     File.join(File.expand_path('../fixtures', __FILE__), *args)
+  end
+
+  def silence
+    # Store the original stderr and stdout in order to restore them later
+    original_stderr = $stderr
+    original_stdout = $stdout
+
+    # Redirect stderr and stdout
+    output = $stderr = $stdout = StringIO.new
+
+    yield
+
+    $stderr = original_stderr
+    $stdout = original_stdout
+
+    # Return output
+    output.to_s
   end
 end
 
 RSpec.configure do |config|
-  config.include Fixtures
+  config.include Helpers
 end


### PR DESCRIPTION
Rails has support for [custom credentials](https://guides.rubyonrails.org/security.html#custom-credentials) that are stored in an encrypted and can be edited by `rails credentials:edit`.

This PR adds support for reading from `Rails.application.credentials` if a variable is not defined in the `ENV`.

TODO:
- [ ] Support for namespaced keys, e.g. `Rails.application.credentials.aws.access_key`
- [ ] Docs

